### PR TITLE
Update stats-entities source reference

### DIFF
--- a/stats-functions/aggregate_hourly_downloads/src/requirements.txt
+++ b/stats-functions/aggregate_hourly_downloads/src/requirements.txt
@@ -4,4 +4,4 @@ google-cloud-logging
 google-cloud-bigquery
 sqlalchemy>=2.0.26
 cloud-sql-python-connector[pymysql] >=1.18.4
-stats-entities @ git+https://github.com/arXiv/stats.git@ARXIVCE-3944-terraform-db#egg=stats_entities&subdirectory=stats-entities
+stats-entities @ git+https://github.com/arXiv/stats.git@main#egg=stats_entities&subdirectory=stats-entities


### PR DESCRIPTION
Ticket(s):  n/a

## Description
This PR updates the branch from which the aggregate hourly downloads cloud functions builds the stats-entities package. (This is necessary only because cloud functions require dependencies in a `requirements.txt` file.)