### PR TITLE
[ARXIVCE-4341] Bugfix OOM and efficiency issues with aggregate hourly downloads

### DIFF
--- a/.github/workflows/deploy-function.yml
+++ b/.github/workflows/deploy-function.yml
@@ -36,7 +36,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'development' }}
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy-function.yml
+++ b/.github/workflows/deploy-function.yml
@@ -36,7 +36,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'development' }}
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code

--- a/stats-functions/aggregate_hourly_downloads/src/config.py
+++ b/stats-functions/aggregate_hourly_downloads/src/config.py
@@ -7,7 +7,7 @@ class Config(FunctionConfig):
     write_db: Optional[DatabaseConfig] = None
 
     max_event_age_in_minutes: int = 50
-    max_query_to_write: int = 1000
+    batch_size_for_category_query: int = 10000
     hour_delay: int = 3
 
     paper_id_regex: str = r"^/[^/]+/([a-zA-Z-]+/[0-9]{7}|[0-9]{4}\.[0-9]{4,5})"

--- a/stats-functions/aggregate_hourly_downloads/src/main.py
+++ b/stats-functions/aggregate_hourly_downloads/src/main.py
@@ -92,23 +92,50 @@ def process_table_rows(
     return download_data_generator(), paper_ids, time_periods, counts
 
 
-def get_paper_categories(paper_ids: Set[str]) -> Dict[str, PaperCategories]:
-    # get the category data for papers
+def get_paper_categories(paper_ids: Set[str]) -> List[Row[Tuple[str, str, int]]]:
     meta = aliased(Metadata)
     dc = aliased(DocumentCategory)
 
-    with ReadSessionFactory() as session:
-        logger.info("Executing read database query")
-        paper_cats = (
-            session.query(meta.paper_id, dc.category, dc.is_primary)
-            .join(meta, dc.document_id == meta.document_id)
-            .filter(meta.paper_id.in_(paper_ids))
-            .filter(meta.is_current == 1)
-            .all()
-        )
-    logger.info("Read database query successfully executed; session closed")
+    id_list = list(paper_ids)
+    all_paper_cats = []
 
-    return paper_cats
+    with ReadSessionFactory() as session:
+        logger.info(
+            f"Executing read database query for {len(id_list)} papers in batches of {config.batch_size_for_category_query}"
+        )
+        for i in range(0, len(id_list), config.batch_size_for_category_query):
+            batch = id_list[i : i + config.batch_size_for_category_query]
+            results = (
+                session.query(meta.paper_id, dc.category, dc.is_primary)
+                .join(meta, dc.document_id == meta.document_id)
+                .filter(meta.paper_id.in_(batch))
+                .filter(meta.is_current == 1)
+                .all()
+            )
+            all_paper_cats.extend(results)
+
+    logger.info("Read database queries successfully executed; session closed")
+
+    return all_paper_cats
+
+
+# def get_paper_categories(paper_ids: Set[str]) -> Dict[str, PaperCategories]:
+#     # get the category data for papers
+#     meta = aliased(Metadata)
+#     dc = aliased(DocumentCategory)
+
+#     with ReadSessionFactory() as session:
+#         logger.info("Executing read database query")
+#         paper_cats = (
+#             session.query(meta.paper_id, dc.category, dc.is_primary)
+#             .join(meta, dc.document_id == meta.document_id)
+#             .filter(meta.paper_id.in_(paper_ids))
+#             .filter(meta.is_current == 1)
+#             .all()
+#         )
+#     logger.info("Read database query successfully executed; session closed")
+
+#     return paper_cats
 
 
 def process_paper_categories(
@@ -136,16 +163,12 @@ def aggregate_data(
     """
     logger.info("Aggregating download data")
     all_data: Dict[DownloadKey, DownloadCounts] = {}
-    missing_data: List[str] = []
     missing_data_count = 0
+
     for entry in download_data:
-        try:
-            cats = paper_categories[entry.paper_id]
-        except KeyError:
+        cats = paper_categories.get(entry.paper_id)
+        if not cats:
             missing_data_count += 1
-            (
-                missing_data.append(entry.paper_id) if len(missing_data) < 20 else None
-            )  # dont make the list too long
             continue  # dont process this paper
 
         # record primary
@@ -156,9 +179,8 @@ def aggregate_data(
             cats.primary.in_archive,
             cats.primary.id,
         )
-        value = all_data.get(key, DownloadCounts())
-        value.primary += entry.num
-        all_data[key] = value
+        counts = all_data.setdefault(key, DownloadCounts())
+        counts.primary += entry.num
 
         # record for each cross
         for cat in cats.crosses:
@@ -169,14 +191,13 @@ def aggregate_data(
                 cat.in_archive,
                 cat.id,
             )
-            value = all_data.get(key, DownloadCounts())
-            value.cross += entry.num
-            all_data[key] = value
+            counts = all_data.setdefault(key, DownloadCounts())
+            counts.cross += entry.num
 
     if missing_data_count > 10:
         time = download_data[0].time if download_data else "Unknown"
         logger.warning(
-            f"{time} Could not find category data for {missing_data_count} paper_ids (may be invalid) \n Example paper_ids with no category data: {missing_data}"
+            f"{time}: Could not find category data for {missing_data_count} paper_ids (may be invalid)"
         )
 
     return all_data
@@ -233,7 +254,7 @@ def perform_aggregation(
     problem_row_count = counts["problem"]
 
     time_period_str = ", ".join([t.strftime("%Y-%m-%d %H:%M:%S") for t in time_periods])
-    
+
     if problem_row_count > 30:
         logger.warning(
             f"{time_period_str}: Problem processing {problem_row_count} rows"
@@ -242,7 +263,7 @@ def perform_aggregation(
     # find categories for all the papers
     query_results = get_paper_categories(paper_ids)
     paper_categories = process_paper_categories(query_results)
-    
+
     if fetched_count > 0 and not paper_categories:
         logger.error(f"{time_period_str}: No category data retrieved from database!")
         raise NoRetryError

--- a/stats-functions/aggregate_hourly_downloads/src/main.py
+++ b/stats-functions/aggregate_hourly_downloads/src/main.py
@@ -119,25 +119,6 @@ def get_paper_categories(paper_ids: Set[str]) -> List[Row[Tuple[str, str, int]]]
     return all_paper_cats
 
 
-# def get_paper_categories(paper_ids: Set[str]) -> Dict[str, PaperCategories]:
-#     # get the category data for papers
-#     meta = aliased(Metadata)
-#     dc = aliased(DocumentCategory)
-
-#     with ReadSessionFactory() as session:
-#         logger.info("Executing read database query")
-#         paper_cats = (
-#             session.query(meta.paper_id, dc.category, dc.is_primary)
-#             .join(meta, dc.document_id == meta.document_id)
-#             .filter(meta.paper_id.in_(paper_ids))
-#             .filter(meta.is_current == 1)
-#             .all()
-#         )
-#     logger.info("Read database query successfully executed; session closed")
-
-#     return paper_cats
-
-
 def process_paper_categories(
     data: List[Row[Tuple[str, str, int]]],
 ) -> Dict[str, PaperCategories]:

--- a/stats-functions/aggregate_hourly_downloads/src/main.py
+++ b/stats-functions/aggregate_hourly_downloads/src/main.py
@@ -49,63 +49,47 @@ WriteSessionFactory = None
 
 def process_table_rows(
     rows: Union[RowIterator, _EmptyRowIterator],
-) -> Tuple[List[DownloadData], Set[str], str, int, int, List[datetime]]:
+) -> Tuple[
+    Any, Set[str], Set[datetime], int, int
+]:  # Changed return types to accommodate generator
     """
     processes rows of data from bigquery
-    returns the list of download data, a set of all unique paper_ids and a string of the time periods this covers
+    returns a generator pointing to download data, a set of all unique paper_ids, and a set of the time periods this covers
     """
-    # process and store returned data
     paper_ids = set()  # only look things up for each paper once
-    download_data: List[DownloadData] = []  # not a dictionary because no unique keys
-    problem_rows: List[Tuple[Any], Exception] = []
-    problem_row_count = 0
-    bad_id_count = 0
-    time_periods = []
-    for row in rows:
-        try:
-            d_type = (
-                "src" if row["download_type"] == "e-print" else row["download_type"]
-            )  # combine e-print and src downloads
-            paper_id = Identifier(row["paper_id"]).id
-            download_data.append(
-                DownloadData(
+    time_periods = set()  # Changed to set for O(1) lookups
+    counts = {"bad_id": 0, "problem": 0}
+
+    # Use a generator to avoid "double memory" hit of list + iterator
+    def download_data_generator():
+        for row in rows:
+            try:
+                d_type = (
+                    "src" if row["download_type"] == "e-print" else row["download_type"]
+                )  # combine e-print and src downloads
+                paper_id = Identifier(row["paper_id"]).id
+                dt = row["start_dttm"].replace(
+                    minute=0, second=0, microsecond=0
+                )  # bucketing by hour
+
+                paper_ids.add(paper_id)
+                time_periods.add(dt)
+
+                yield DownloadData(
                     paper_id=paper_id,
                     country=row["geo_country"],
                     download_type=d_type,
-                    time=row["start_dttm"].replace(
-                        minute=0, second=0, microsecond=0
-                    ),  # bucketing by hour
+                    time=dt,
                     num=row["num_downloads"],
                 )
-            )
-            paper_ids.add(paper_id)
-        except IdentifierException:
-            bad_id_count += 1
-            continue  # dont count this download
-        except Exception as e:
-            problem_row_count += 1
-            problem_rows.append((tuple(row), e)) if len(problem_rows) < 20 else None
-            continue  # dont count this download
-        time_period = row["start_dttm"].replace(minute=0, second=0, microsecond=0)
-        if time_period not in time_periods:
-            time_periods.append(time_period)
+            except IdentifierException:
+                counts["bad_id"] += 1
+                continue
+            except Exception:
+                counts["problem"] += 1
+                continue
 
-    time_period_str = ", ".join(
-        [date.strftime("%Y-%m-%d %H:%M:%S") for date in time_periods]
-    )
-    if problem_row_count > 30:
-        logger.warning(
-            f"{time_period_str}: Problem processing {problem_row_count} rows \n Selection of problem row errors: {problem_rows}"
-        )
-
-    return (
-        download_data,
-        paper_ids,
-        time_period_str,
-        bad_id_count,
-        problem_row_count,
-        time_periods,
-    )
+    return download_data_generator(), paper_ids, time_periods, counts
 
 
 def get_paper_categories(paper_ids: Set[str]) -> Dict[str, PaperCategories]:
@@ -190,7 +174,7 @@ def aggregate_data(
             all_data[key] = value
 
     if missing_data_count > 10:
-        time = download_data[0].time
+        time = download_data[0].time if download_data else "Unknown"
         logger.warning(
             f"{time} Could not find category data for {missing_data_count} paper_ids (may be invalid) \n Example paper_ids with no category data: {missing_data}"
         )
@@ -200,26 +184,22 @@ def aggregate_data(
 
 def insert_into_database(
     aggregated_data: Dict[DownloadKey, DownloadCounts],
-    time_periods: List[datetime],
+    time_periods: Set[datetime],  # Changed to Set
 ) -> int:
     """adds the data from an hour of downloads into the database
     uses bulk insert and update statements to increase efficiency
-    first compiles all the keys for the data we would like to add and checks for their presence in the database
-    present items are added to run update for, and removed from the aggregated dictionary
-    remaining items are inserted
-    data with duplicate keys will be overwritten to allow for reruns with updates
-    returns the number of rows added and updated
     """
+    # Optimized: Use raw dicts for bulk_insert_mappings (much faster than bulk_save_objects)
     data_to_insert = [
-        HourlyDownloads(
-            country=key.country,
-            download_type=key.download_type,
-            archive=key.archive,
-            category=key.category,
-            primary_count=counts.primary,
-            cross_count=counts.cross,
-            start_dttm=key.time,
-        )
+        {
+            "country": key.country,
+            "download_type": key.download_type,
+            "archive": key.archive,
+            "category": key.category,
+            "primary_count": counts.primary,
+            "cross_count": counts.cross,
+            "start_dttm": key.time,
+        }
         for key, counts in aggregated_data.items()
     ]
 
@@ -227,15 +207,11 @@ def insert_into_database(
         logger.info("Executing write database transaction")
         # remove previous data for the time period
         session.query(HourlyDownloads).filter(
-            HourlyDownloads.start_dttm.in_(time_periods)
+            HourlyDownloads.start_dttm.in_(list(time_periods))
         ).delete(synchronize_session=False)
 
-        # add data
-        for i in range(
-            0, len(data_to_insert), config.max_query_to_write
-        ):  # to conform to db stack size limit
-            session.bulk_save_objects(data_to_insert[i : i + config.max_query_to_write])
-
+        # High-performance bulk insert skipping ORM object state overhead
+        session.bulk_insert_mappings(HourlyDownloads, data_to_insert)
         session.commit()
 
     logger.info("Write database transaction successfully committed; session closed")
@@ -247,22 +223,27 @@ def perform_aggregation(
     rows: Union[RowIterator, _EmptyRowIterator],
 ) -> AggregationResult:
     logger.info("Processing results of log query")
-    (
-        download_data,
-        paper_ids,
-        time_period_str,
-        bad_id_count,
-        problem_row_count,
-        time_periods,
-    ) = process_table_rows(rows)
+    data_gen, paper_ids, time_periods, counts = process_table_rows(rows)
 
+    # Consume generator into list to populate paper_ids for the next DB query
+    download_data = list(data_gen)
     fetched_count = len(download_data)
     unique_id_count = len(paper_ids)
+    bad_id_count = counts["bad_id"]
+    problem_row_count = counts["problem"]
+
+    time_period_str = ", ".join([t.strftime("%Y-%m-%d %H:%M:%S") for t in time_periods])
+    
+    if problem_row_count > 30:
+        logger.warning(
+            f"{time_period_str}: Problem processing {problem_row_count} rows"
+        )
 
     # find categories for all the papers
     query_results = get_paper_categories(paper_ids)
     paper_categories = process_paper_categories(query_results)
-    if len(paper_categories) == 0:
+    
+    if fetched_count > 0 and not paper_categories:
         logger.error(f"{time_period_str}: No category data retrieved from database!")
         raise NoRetryError
 

--- a/stats-functions/aggregate_hourly_downloads/tests/test_aggregate_download_data.py
+++ b/stats-functions/aggregate_hourly_downloads/tests/test_aggregate_download_data.py
@@ -117,28 +117,12 @@ def write_session_factory():
 
 
 def test_process_table_rows_success_valid_and_invalid_rows():
-    def mock_row_generator():
-        yield {
-            "paper_id": "2301.00001",
-            "download_type": "pdf",
-            "geo_country": "US",
-            "start_dttm": datetime(2026, 2, 9, 10, 0, 0),
-            "num_downloads": 1,
-        }
-        yield {
-            "paper_id": "2301.00002",
-            "download_type": "pdf",
-            "geo_country": "DE",
-            "start_dttm": datetime(2026, 2, 9, 10, 0, 0),
-            "num_downloads": 5,
-        }
-
     (
         download_data_gen,
         paper_ids,
         time_periods,
         counts,
-    ) = process_table_rows(mock_row_generator)
+    ) = process_table_rows(fake_rows_from_bq)
 
     download_data = list(download_data_gen)
 

--- a/stats-functions/aggregate_hourly_downloads/tests/test_aggregate_download_data.py
+++ b/stats-functions/aggregate_hourly_downloads/tests/test_aggregate_download_data.py
@@ -72,32 +72,6 @@ fake_rows_from_bq = [
 ]
 
 
-# @pytest.fixture
-# def fake_row_generator():
-#     rows = [
-#         {
-#             "paper_id": "2301.00001",
-#             "geo_country": "US",
-#             "download_type": "src",
-#             "start_dttm": datetime(2026, 2, 9, 10, 0, 0),
-#             "num_downloads": 10,
-#         },
-#         {
-#             "paper_id": "2301.00002",
-#             "geo_country": "DE",
-#             "download_type": "pdf",
-#             "start_dttm": datetime(2026, 2, 9, 10, 0, 0),
-#             "num_downloads": 5,
-#         },
-#     ]
-
-#     def _generate():
-#         for row in rows:
-#             yield row
-
-#     return _generate
-
-
 @pytest.fixture
 def read_session_factory():
     engine = create_engine("sqlite:///:memory:")

--- a/stats-functions/aggregate_hourly_downloads/tests/test_aggregate_download_data.py
+++ b/stats-functions/aggregate_hourly_downloads/tests/test_aggregate_download_data.py
@@ -122,14 +122,14 @@ def test_process_table_rows_success_valid_and_invalid_rows():
             "paper_id": "2301.00001",
             "download_type": "pdf",
             "geo_country": "US",
-            "start_dttm": datetime.now(),
+            "start_dttm": datetime(2026, 2, 9, 10, 0, 0),
             "num_downloads": 1,
         }
         yield {
             "paper_id": "2301.00002",
             "download_type": "pdf",
             "geo_country": "DE",
-            "start_dttm": datetime.now(),
+            "start_dttm": datetime(2026, 2, 9, 10, 0, 0),
             "num_downloads": 5,
         }
 
@@ -138,7 +138,7 @@ def test_process_table_rows_success_valid_and_invalid_rows():
         paper_ids,
         time_periods,
         counts,
-    ) = process_table_rows(fake_rows_from_bq)
+    ) = process_table_rows(mock_row_generator)
 
     download_data = list(download_data_gen)
 

--- a/stats-functions/aggregate_hourly_downloads/tests/test_aggregate_download_data.py
+++ b/stats-functions/aggregate_hourly_downloads/tests/test_aggregate_download_data.py
@@ -40,7 +40,7 @@ from stats_entities.site_usage import SiteUsageBase, HourlyDownloads
 from arxiv_functions.exception import NoRetryError
 
 
-mock_rows_from_bq = [
+fake_rows_from_bq = [
     {
         "paper_id": "2301.00001",
         "geo_country": "US",
@@ -70,6 +70,32 @@ mock_rows_from_bq = [
         "num_downloads": 2,
     },
 ]
+
+
+# @pytest.fixture
+# def fake_row_generator():
+#     rows = [
+#         {
+#             "paper_id": "2301.00001",
+#             "geo_country": "US",
+#             "download_type": "src",
+#             "start_dttm": datetime(2026, 2, 9, 10, 0, 0),
+#             "num_downloads": 10,
+#         },
+#         {
+#             "paper_id": "2301.00002",
+#             "geo_country": "DE",
+#             "download_type": "pdf",
+#             "start_dttm": datetime(2026, 2, 9, 10, 0, 0),
+#             "num_downloads": 5,
+#         },
+#     ]
+
+#     def _generate():
+#         for row in rows:
+#             yield row
+
+#     return _generate
 
 
 @pytest.fixture
@@ -117,14 +143,30 @@ def write_session_factory():
 
 
 def test_process_table_rows_success_valid_and_invalid_rows():
+    def mock_row_generator():
+        yield {
+            "paper_id": "2301.00001",
+            "download_type": "pdf",
+            "geo_country": "US",
+            "start_dttm": datetime.now(),
+            "num_downloads": 1,
+        }
+        yield {
+            "paper_id": "2301.00002",
+            "download_type": "pdf",
+            "geo_country": "DE",
+            "start_dttm": datetime.now(),
+            "num_downloads": 5,
+        }
+
     (
-        download_data,
+        download_data_gen,
         paper_ids,
-        time_period_str,
-        bad_id_count,
-        problem_row_count,
         time_periods,
-    ) = process_table_rows(mock_rows_from_bq)
+        counts,
+    ) = process_table_rows(fake_rows_from_bq)
+
+    download_data = list(download_data_gen)
 
     assert len(download_data) == 2
     assert download_data[0].paper_id == "2301.00001"
@@ -135,12 +177,11 @@ def test_process_table_rows_success_valid_and_invalid_rows():
     assert "2301.00002" in paper_ids
     assert len(paper_ids) == 2
 
-    assert bad_id_count == 1  # bad id row
-    assert problem_row_count == 1  # missing key row
+    assert counts["bad_id"] == 1  # bad id row
+    assert counts["problem"] == 1  # missing key row
 
     assert len(time_periods) == 1
-    assert time_periods[0] == datetime(2026, 2, 9, 10, 0)
-    assert "2026-02-09 10:00:00" in time_period_str
+    assert datetime(2026, 2, 9, 10, 0) in time_periods
 
 
 def test_get_paper_categories_success(read_session_factory):
@@ -513,7 +554,7 @@ def test_perform_aggregation_success(read_session_factory, write_session_factory
     with patch("main.ReadSessionFactory", read_session_factory), patch(
         "main.WriteSessionFactory", write_session_factory
     ):
-        result = perform_aggregation(mock_rows_from_bq)
+        result = perform_aggregation(fake_rows_from_bq)
 
         assert result.fetched_count == 2
         assert result.unique_ids_count == 2
@@ -536,7 +577,7 @@ def test_perform_aggregation_no_categories_raises_no_retry(
 ):
     rows_with_no_categories = [
         {
-            "paper_id": "9999.99999",
+            "paper_id": "2304.00003",
             "geo_country": "US",
             "download_type": "pdf",
             "start_dttm": datetime(2026, 2, 9, 10, 0, 0),
@@ -544,9 +585,13 @@ def test_perform_aggregation_no_categories_raises_no_retry(
         }
     ]
 
+    def mock_gen():
+        for row in rows_with_no_categories:
+            yield row
+
     with patch("main.ReadSessionFactory", read_session_factory), patch(
         "main.WriteSessionFactory", write_session_factory
     ):
 
         with pytest.raises(NoRetryError):
-            perform_aggregation(rows_with_no_categories)
+            perform_aggregation(mock_gen())


### PR DESCRIPTION
Ticket(s):  https://arxiv-org.atlassian.net/browse/ARXIVCE-4341

## Description
(Aided by Gemini) This PR makes three changes to aggregate hourly downloads:
- First, it switches to a streaming model for download data from BQ - this reduces memory use by not holding both the BQ results and the `download_data` python list in memory at once (we do still have to load the full data for use in aggregation). 
- Second, it switches from using `bulk_save_objects` to `bulk_insert_mappings` - this should speed up db writes.
- Third, it batches the category query against the main db replica - the biggest problem according to logs (taking ~5 min and I'm sure a lot of memory to parse the query) - this should significantly improve performance.

### Changes made
- update main
- update tests

## Testing instructions
Tested in dev (albeit on a small data sample from BQ) - see logs or trigger manually with
`gcloud pubsub topics publish stats-aggregate-hourly-downloads --message="" --attribute="hour=2025-09-0215" --project arxiv-development`