### PR TITLE
[QA-257] Update alerting for hourly downloads cron

### DIFF
--- a/stats-functions/aggregate_hourly_downloads/src/main.py
+++ b/stats-functions/aggregate_hourly_downloads/src/main.py
@@ -246,8 +246,9 @@ def perform_aggregation(
     paper_categories = process_paper_categories(query_results)
 
     if fetched_count > 0 and not paper_categories:
-        logger.error(f"{time_period_str}: No category data retrieved from database!")
-        raise NoRetryError
+        raise NoRetryError(
+            f"{time_period_str}: No category data retrieved from database!"
+        )
 
     # aggregate download data
     aggregated_data = aggregate_data(download_data, paper_categories)
@@ -295,8 +296,7 @@ def query_logs(start_time: str, end_time: str) -> RowIterator:
     if rows.total_rows > 0:
         return rows
     else:
-        logger.error("No log data returned from bigquery!")
-        raise NoRetryError
+        raise NoRetryError("No log data returned from bigquery!")
 
 
 def get_start_and_end_times(hour: datetime) -> tuple[datetime, datetime]:
@@ -310,8 +310,7 @@ def validate_cloud_event(cloud_event: CloudEvent) -> datetime:
     event_time = parse_cloud_event_time(cloud_event)
 
     if event_time_exceeds_retry_window(config, event_time):
-        logger.exception("Event time exceeds retry window!")
-        raise NoRetryError
+        raise NoRetryError("Event time exceeds retry window!")
 
     return (event_time - timedelta(hours=config.hour_delay)).replace(minute=0, second=0)
 
@@ -373,6 +372,11 @@ def aggregate_hourly_downloads(cloud_event: CloudEvent):
 
     except Exception as e:
         # pubsub will retry with a warm start
+        logger.warning(
+            f"Retryable error occurred, pubsub will retry with a warm start: {e}",
+            exc_info=True,
+        )
+
         # clean engine pools to prevent a memory leak inside the warm container
         logger.info("Disposing engine pools to release memory")
 

--- a/terraform/aggregate_hourly_downloads/main.tf
+++ b/terraform/aggregate_hourly_downloads/main.tf
@@ -183,3 +183,31 @@ resource "google_monitoring_alert_policy" "cloud_run_error_alert" {
     mime_type = "text/markdown"
   }
 }
+
+resource "google_monitoring_alert_policy" "cloud_run_oom_alert" {
+  display_name = "${google_cloudfunctions2_function.function.name} OOM"
+  combiner     = "OR"
+  severity     = "ERROR"
+
+  conditions {
+    display_name = "Cloud Run OOM log"
+    condition_matched_log {
+      filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${google_cloudfunctions2_function.function.name}\" AND severity=ERROR AND textPayload=~\"Memory limit of.*exceeded\""
+    }
+  }
+
+  alert_strategy {
+    notification_rate_limit {
+      period = "300s" # limit notifications to every 5 minutes
+    }
+  }
+
+  notification_channels = [
+    "projects/${var.gcp_project_id}/notificationChannels/${var.slack_channel_id}"
+  ]
+
+  documentation {
+    content   = "Cloud Run service ${google_cloudfunctions2_function.function.name} was killed for exceeding its memory limit (OOM) - see logs to determine whether the container's available_memory needs to be increased or whether the function is leaking/overusing memory."
+    mime_type = "text/markdown"
+  }
+}

--- a/terraform/aggregate_hourly_downloads/main.tf
+++ b/terraform/aggregate_hourly_downloads/main.tf
@@ -157,14 +157,14 @@ resource "google_cloud_scheduler_job" "invoke_cloud_function" {
 ### alerting ###
 
 resource "google_monitoring_alert_policy" "cloud_run_error_alert" {
-  display_name = "${google_cloudfunctions2_function.function.name} logging errors"
+  display_name = "${google_cloudfunctions2_function.function.name} NoRetryError"
   combiner     = "OR"
   severity     = "ERROR"
 
   conditions {
-    display_name = "Cloud Run error log"
+    display_name = "Cloud Run NoRetryError log"
     condition_matched_log {
-      filter = "resource.type=\"cloud_run_revision\" AND severity=(\"ERROR\" OR \"CRITICAL\" OR \"ALERT\" OR \"EMERGENCY\") AND resource.labels.service_name=\"${google_cloudfunctions2_function.function.name}\""
+      filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${google_cloudfunctions2_function.function.name}\" AND jsonPayload.message=~\"A NoRetry exception has been raised\""
     }
   }
 
@@ -179,7 +179,7 @@ resource "google_monitoring_alert_policy" "cloud_run_error_alert" {
   ]
 
   documentation {
-    content   = "Cloud Run service ${google_cloudfunctions2_function.function.name} has reported an error - see logs."
+    content   = "Cloud Run service ${google_cloudfunctions2_function.function.name} raised a NoRetryError and will not retry - see logs, fix the problem, and manually run the function to patch data as needed."
     mime_type = "text/markdown"
   }
 }


### PR DESCRIPTION
Ticket(s):  https://arxiv-org.atlassian.net/browse/QA-257

## Description
This PR adjusts logging and narrows the scope of the basic alert for the hourly downloads cron to only trigger when a NoRetryError is raised. A NoRetryError will also occur after 50 minutes of unsuccessful retries, if not earlier (depending on the exception type).

It also adds a second alert that triggers when a container is OOM.

### Changes made
- Update logging
- Adjust first alert
- Add second alert

## Testing instructions
Will deploy to dev on merge