### PR TITLE
Bugfix alert query

### DIFF
--- a/.github/workflows/aggregate-hourly-downloads-triggers.yml
+++ b/.github/workflows/aggregate-hourly-downloads-triggers.yml
@@ -29,6 +29,7 @@ jobs:
 
   call-deploy:
     needs: call-lint-test
+    # if: github.ref == 'refs/heads/main'
     name: Deploy hourly downloads
     uses: ./.github/workflows/deploy-function.yml
     with:

--- a/.github/workflows/aggregate-hourly-downloads-triggers.yml
+++ b/.github/workflows/aggregate-hourly-downloads-triggers.yml
@@ -29,7 +29,7 @@ jobs:
 
   call-deploy:
     needs: call-lint-test
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     name: Deploy hourly downloads
     uses: ./.github/workflows/deploy-function.yml
     with:

--- a/.github/workflows/deploy-function.yml
+++ b/.github/workflows/deploy-function.yml
@@ -36,7 +36,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'development' }}
-    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/hourly-edge-requests-triggers.yml
+++ b/.github/workflows/hourly-edge-requests-triggers.yml
@@ -29,6 +29,7 @@ jobs:
 
   call-deploy:
     needs: call-lint-test
+    if: github.ref == 'refs/heads/main'
     name: Deploy hourly edge requests
     uses: ./.github/workflows/deploy-function.yml
     with:

--- a/.github/workflows/monthly-downloads-triggers.yml
+++ b/.github/workflows/monthly-downloads-triggers.yml
@@ -29,6 +29,7 @@ jobs:
 
   call-deploy:
     needs: call-lint-test
+    if: github.ref == 'refs/heads/main'
     name: Deploy monthly downloads
     uses: ./.github/workflows/deploy-function.yml
     with:

--- a/.github/workflows/monthly-submissions-triggers.yml
+++ b/.github/workflows/monthly-submissions-triggers.yml
@@ -29,6 +29,7 @@ jobs:
 
   call-deploy:
     needs: call-lint-test
+    if: github.ref == 'refs/heads/main'
     name: Deploy monthly submissions
     uses: ./.github/workflows/deploy-function.yml
     with:

--- a/terraform/aggregate_hourly_downloads/main.tf
+++ b/terraform/aggregate_hourly_downloads/main.tf
@@ -169,7 +169,7 @@ resource "google_monitoring_alert_policy" "cloud_run_error_alert" {
   conditions {
     display_name = "Cloud Run NoRetryError log"
     condition_matched_log {
-      filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${google_cloudfunctions2_function.function.name}\" AND jsonPayload.message=~\"A NoRetry exception has been raised\""
+      filter = "resource.type=\"cloud_run_revision\" AND resource.labels.service_name=\"${google_cloudfunctions2_function.function.name}\" AND textPayload=~\"A NoRetry exception has been raised\""
     }
   }
 


### PR DESCRIPTION
Ticket(s):  n/a

## Description
This PR updates the aggregate hourly downloads alert - it was not firing because the log query was incorrect.

It also moves the deploy condition to triggers for each function, rather that the deploy workflow, to make it easier to manually deploy from PR for testing.

### Changes made
- update log query in alert
- move if condition to triggers from deploy-function.yml

## Testing instructions
Tested on dev